### PR TITLE
Fix support for 0 as a path params

### DIFF
--- a/src/backbone.giraffe.coffee
+++ b/src/backbone.giraffe.coffee
@@ -1255,11 +1255,11 @@ class Giraffe.Router extends Backbone.Router
     if _.isObject(first)
       result = route.replace wildcards, (token, index) ->
         key = token.slice(1)
-        if first[key]? then first[key] else ''
+        first[key] ? ''
     else
       result = route.replace wildcards, (token, index) ->
         value = args.shift()
-        if value? then value else ''
+        value ? ''
 
     result
 


### PR DESCRIPTION
`first[key] || ''` changes `0` into `''` which is a problem when dealing with simple indexes.
