### PR TITLE
Add contrib.js

### DIFF
--- a/contrib.js
+++ b/contrib.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/backbone.giraffe.contrib');


### PR DESCRIPTION
Requiring contrib (in Browserify, webpack, etc) is currently really ugly:

``` js
var CollectionView = require('backbone.giraffe/dist/backbone.giraffe.contrib').CollectionView;
```

This makes it prettier :)

``` js
var CollectionView = require('backbone.giraffe/contrib').CollectionView;
```
